### PR TITLE
Prevent PHPUnit 9.5 and higher

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ script:
     - ./run-tests.sh ^6.5.14 || travis_terminate 1
     - ./run-tests.sh ^7.5.20 || travis_terminate 1
     - ./run-tests.sh ~8.5 || travis_terminate 1
-    - ./run-tests.sh ~9.4 || travis_terminate 1
+    - ./run-tests.sh ~9.4.0 || travis_terminate 1
 
 jobs:
     include:

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": "^5.5 || ^7.0 || ^8.0",
-        "phpunit/phpunit": "^4.8.36 || ^5.7.27 || ^6.5.14 || ^7.5.20 || ~8.5 || ~9.4"
+        "phpunit/phpunit": "^4.8.36 || ^5.7.27 || ^6.5.14 || ^7.5.20 || ~8.5 || ~9.4.0"
     },
     "require-dev": {
         "phpunitgoodpractices/polyfill": "^1.1",


### PR DESCRIPTION
it's crashing on 9.5 and I have no time myself to figure out how to fix it in most compatible way.

reason for crash described in https://github.com/php-coveralls/php-coveralls/pull/346#issuecomment-1230079070